### PR TITLE
Fix UTF-8 Character Handling

### DIFF
--- a/src/locales/win_se.h
+++ b/src/locales/win_se.h
@@ -31,6 +31,12 @@
          {"}", USBKeyDefinition(USBKeyDefinition::UsbHidModifiers::RightAlt, 0x27)},
          {"\\", USBKeyDefinition(USBKeyDefinition::UsbHidModifiers::RightAlt, 0x2d)},
          {"|", USBKeyDefinition(USBKeyDefinition::UsbHidModifiers::RightAlt, 0x64)},
+         {"å", USBKeyDefinition(0x2f)},
+         {"Å", USBKeyDefinition(USBKeyDefinition::UsbHidModifiers::LeftShift, 0x2f)},
+         {"ö", USBKeyDefinition(0x33)},
+         {"Ö", USBKeyDefinition(USBKeyDefinition::UsbHidModifiers::LeftShift, 0x33)},
+         {"ä", USBKeyDefinition(0x34)},
+         {"Ä", USBKeyDefinition(USBKeyDefinition::UsbHidModifiers::LeftShift, 0x34)},
      }},
 
 #endif


### PR DESCRIPTION
## Description
Improves the STRING and STRINGLN commands to properly handle multi-byte UTF-8 characters when processing keyboard input. Previously, UTF-8 characters were processed byte-by-byte, which could result in incorrect character output for non-ASCII characters.

## Changes
- Added UTF-8 character length detection based on first byte
- Modified string processing to extract complete UTF-8 characters instead of individual bytes
- Improved logging for UTF-8 character processing
- Added support for 2, 3, and 4 byte UTF-8 sequences
- Fixed some special characters for win_se